### PR TITLE
fix: 如果是主分支则不显示版本号，直接显示 latest。不论什么情况都显示部署 hash 并链接到 github。

### DIFF
--- a/.github/workflows/deploy-tag-to-vercel.yml
+++ b/.github/workflows/deploy-tag-to-vercel.yml
@@ -37,5 +37,5 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          chmod +x ./deploy-version.sh
-          ./deploy-version.sh
+          chmod +x ./deploy-with-tag.sh
+          ./deploy-with-tag.sh

--- a/deploy-with-tag.sh
+++ b/deploy-with-tag.sh
@@ -4,17 +4,27 @@
 TAG=$(git describe --tags --abbrev=0)
 VERSION=${TAG#v} # 移除 v 前缀
 
+# 获取当前提交哈希
+COMMIT_SHA=$(git rev-parse HEAD)
+
+# 获取当前分支名
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
 # 生成唯一部署名称
 DEPLOY_NAME="nextjs-${VERSION}"
 DOMAIN="${DEPLOY_NAME}.0human.website"
 
 echo "Building version ${VERSION}..."
+echo "Current commit SHA: ${COMMIT_SHA}"
+echo "Current branch: ${BRANCH_NAME}"
 
 # 1. 部署到 Vercel
 DEPLOY_OUTPUT=$(npx vercel deploy --yes \
   --scope 0human \
   --token $VERCEL_TOKEN \
-  --build-env NEXT_PUBLIC_VERSION=$VERSION)
+  --build-env NEXT_PUBLIC_VERSION=$VERSION \
+  --build-env NEXT_PUBLIC_COMMIT_SHA=$COMMIT_SHA \
+  --build-env NEXT_PUBLIC_BRANCH=$BRANCH_NAME)
 
 # 2. 获取部署 URL
 DEPLOYMENT_URL=$(echo "$DEPLOY_OUTPUT" | grep -o 'https://[^ ]*\.vercel\.app' | head -1)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,7 +122,20 @@ export default function Home() {
       </main>
       
       <footer className="mt-12 text-center text-slate-500 dark:text-slate-400">
-        <p>当前版本：{process.env.NEXT_PUBLIC_VERSION}</p>
+        <p>当前版本：{process.env.NEXT_PUBLIC_BRANCH === 'main' || process.env.NEXT_PUBLIC_BRANCH === 'master' ? 'latest' : process.env.NEXT_PUBLIC_VERSION}</p>
+        <p>
+          部署哈希：
+          {process.env.NEXT_PUBLIC_COMMIT_SHA && (
+            <a 
+              href={`https://github.com/0human/nextjs-website/commit/${process.env.NEXT_PUBLIC_COMMIT_SHA}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+            >
+              {process.env.NEXT_PUBLIC_COMMIT_SHA.substring(0, 7)}
+            </a>
+          )}
+        </p>
         <p>© {new Date().getFullYear()} Next.js Website Project</p>
       </footer>
     </div>


### PR DESCRIPTION
https://github.com/0human/nextjs-website/issues/9#issuecomment-3235939027